### PR TITLE
fix: checking steps getting only step 0

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -227,7 +227,7 @@ def main():
     )
 
     # Separate data in train and test only if steps 1 and 2 are done
-    if all(steps[:-1]):
+    if all(steps):
         X_train, y_train = get_X_y_data(df_train, feature_cols=feat_names_list, target_col=target_name)
         X_to_predict = get_X_y_data(df_test, feature_cols=feat_names_list)
 
@@ -235,7 +235,7 @@ def main():
     clicked_on_run = st.button(f"Run {option.lower()} model")
     
     if clicked_on_run:
-        if not all(steps[:-1]):
+        if not all(steps):
             with st.empty():
                 show_error(steps)
         else:


### PR DESCRIPTION
## The problem:
When checking the variable `steps`, which is a **list of length 2** that keeps tracking of the state of the required steps to run the model (upload train data and test data), only the first position step was taken in account:

``` python
if all(steps[:-1]):
```
As it was checking all positions except the last one, it was actually getting only the first position because there are only two steps `[step0, step1]`.

## The fix:
Check all array instead of segmenting it:
``` python
if all(steps):
```
