### PR TITLE
fix: always running classification

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -246,6 +246,7 @@ def main():
                 feature_cols=feat_names_list,
                 target_col=target_name,
                 nominal_cols=nominal_feat_names,
+                task=option,
             )
             st.session_state.run_model = True
 


### PR DESCRIPTION
## Problem:

If we select either `classification` or `regression`, the task is always run as `classification`.

## Solution:

pass the return of the radio button as the `task` parameter on `run_pipeline()`